### PR TITLE
GEO-30 Add support for imagemosaic coveragestores #review

### DIFF
--- a/src/geosync/core.clj
+++ b/src/geosync/core.clj
@@ -162,7 +162,7 @@
                                                 store-name
                                                 {:file-url (s/replace file-url "imagemosaic_properties.zip" "")})
                     (rest/update-coverage-store-image-mosaic geoserver-workspace store-name file-url)
-                    (rest/create-coverage geoserver-workspace store-name store-name)
+                    (rest/create-coverage geoserver-workspace store-name store-name layer-name)
                     (when style
                       (rest/update-layer-style geoserver-workspace store-name style :raster))]
 

--- a/src/geosync/rest_api.clj
+++ b/src/geosync/rest_api.clj
@@ -328,13 +328,13 @@
     (str "/workspaces/" workspace "/coveragestores/" store "/coverages/" coverage)
     nil]))
 
-(defn create-coverage [workspace store coverage]
+(defn create-coverage [workspace store coverage layer-name]
   ["POST"
    (str "/workspaces/" workspace "/coveragestores/" store "/coverages")
    (xml
     [:coverage
      [:name coverage]
-     [:nativeCoverageName coverage]])])
+     [:nativeName layer-name]])])
 
 ;; FIXME: GeoSync coverages load incorrectly:
 ;; - Dimensions tab throws errors (the coverageName "foo" is not supported)


### PR DESCRIPTION
----

## Purpose
Updated geosync.core and geosync.rest-api functions to enable
detection and registration of directories containing an
imagemosaic_properties.zip file as a GeoServer imagemosaic
coveragestore.

## Related Issues
Closes GEO-30

## Submission Checklist
- [ ] Commits include the JIRA issue and the `#review` hashtag (e.g. `GEO-### #review <comment>`)
- [ ] Code passes linter rules (`clj-kondo --lint src`)
- [ ] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
<!-- Create a BDD style test script -->
1. Given..., When ..., Then ....

## Screenshots
<!-- Add a screen shot when UI changes are included -->