### PR TITLE
GEO-52 Use passed param for database in create_db.sql

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,7 +6,7 @@
            org.clojure/data.json  {:mvn/version "2.0.1"}
            org.clojure/tools.cli  {:mvn/version "1.0.206"}
            sig-gis/triangulum     {:git/url "https://github.com/sig-gis/triangulum"
-                                   :sha     "ded7a3afbb667405542822f7e07b7a1d3acae432"}
+                                   :sha     "8b352e775dba2380b8615e13b17425d222ccb1bd"}
            com.taoensso/tufte     {:mvn/version "2.2.0"}}
  :aliases {:run              {:main-opts ["-m" "geosync.cli"]}
            :build-db         {:main-opts ["-m" "triangulum.build-db"]}

--- a/src/sql/create_db.sql
+++ b/src/sql/create_db.sql
@@ -1,6 +1,6 @@
-DROP DATABASE IF EXISTS geoserver;
+DROP DATABASE IF EXISTS :database;
 DROP ROLE IF EXISTS geoserver;
 CREATE ROLE geoserver WITH LOGIN CREATEDB PASSWORD 'geoserver';
-CREATE DATABASE geoserver WITH OWNER geoserver;
-\c geoserver
+CREATE DATABASE :database WITH OWNER geoserver;
+\c :database
 CREATE EXTENSION postgis;


### PR DESCRIPTION
## Purpose
Use passed param for database in create_db.sql.  This allows the dev geosync to use a differently named db.

## Related Issues
Closes GEO-52

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GEO-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
1. When I use the -d database cli command, Then I am able to use the :database variable in my create_db.sql script.