### PR TITLE
GEO-51 Add ability to remove single layer via server mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -154,6 +154,19 @@ is provided, all workspaces matching the regex will be deleted.
  "responsePort":       5555}
 #+end_src
 
+1. Remove a single layer and it's associated store under a Workspace from Geoserver
+
+Both ~geoserverWorkspace~ and ~geoserverLayer~ are plain texts that must
+match the exact entries in Geoserver.
+
+#+begin_src js
+{"action":             "remove",
+ "geoserverWorkspace": "demo",
+ "geoserverLayer":     "demo-layer",
+ "responseHost":       "my.server.org",
+ "responsePort":       5555}
+#+end_src
+
 Because GeoServer updates can take awhile to complete, these requests
 are processed asynchronously. This means that the network connection
 will be closed as soon as the incoming request is read from the

--- a/src/geosync/core.clj
+++ b/src/geosync/core.clj
@@ -484,3 +484,16 @@
                    (and acc)))
             true
             workspaces)))
+
+(defn remove-layer!
+  [{:keys [geoserver-workspace geoserver-layer] :as config-params}]
+  (when (workspace-exists? config-params)
+    (reduce (fn [acc f]
+              (->> (f geoserver-workspace geoserver-layer true)
+                   (make-rest-request config-params)
+                   (:status)
+                   (success-code?)
+                   (or acc)))
+            false
+            [rest/delete-data-store
+             rest/delete-coverage-store])))

--- a/src/geosync/rest_api.clj
+++ b/src/geosync/rest_api.clj
@@ -155,10 +155,14 @@
       [:entry {:key "memory mapped buffer"} true]
       [:entry {:key "cache and reuse memory maps"} true]]])])
 
-(defn delete-data-store [workspace store]
-  ["DELETE"
-   (str "/workspaces/" workspace "/datastores/" store)
-   nil])
+(defn delete-data-store
+  ([workspace store]
+   (delete-data-store workspace store false))
+
+  ([workspace store recurse?]
+   ["DELETE"
+    (str "/workspaces/" workspace "/datastores/" store "?recurse=" recurse?)
+    nil]))
 
 ;;=================================================================================
 ;;
@@ -211,10 +215,14 @@
    file-url
    "text/plain"])
 
-(defn delete-coverage-store [workspace store]
-  ["DELETE"
-   (str "/workspaces/" workspace "/coveragestores/" store)
-   nil])
+(defn delete-coverage-store
+  ([workspace store]
+   (delete-coverage-store workspace store false))
+
+  ([workspace store recurse?]
+   ["DELETE"
+    (str "/workspaces/" workspace "/coveragestores/" store "?recurse=" recurse?)
+    nil]))
 
 ;;=================================================================================
 ;;


### PR DESCRIPTION
-------

## Purpose

Add ability to remove single layer via server mode

## Related Issues
Closes GEO-51

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GEO-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [ ] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing

1. Launch geosync-server in your repl. Modify params according do your
   development setup.

``` clojure
(do
  (use '[geosync.cli])
  (start-server! (add-derived-params
                  {:geosync-server-host "localhost"
                   :geosync-server-port 8082
                   :geoserver-username  "admin"
                   :geoserver-password  "geoserver"
                   :geoserver-rest-uri  "http://localhost:8080/geoserver/rest"
                   :file-watcher        {:dir             "/srv/data"
                                         :workspace-regex {"fire_detections" #"(?<=/)fire_detections/[\w]+"}
                                         :dev             false}})))
```

2. Register fire detection layers from `data.pyregence.org` by scp-ing
the folder to the fire_detections directory that is monitored by the
file-watcher (i.e. /srv/data/fire_detections). Make sure the `viirs`
folder does not already exist otherwise layers will not be registered.

``` shell
cd /srv/data/fire_detections
scp -r geoserver@data:/var/www/html/fire_detections/viirs .
```

3. Send the request to remove a single layer from the workspace.

``` clojure
(def request {:action              "remove",
              :geoserver-workspace "fire_detections_viirs",
              :geoserver-layer     "viirs-timestamped_20210924_150000"
              :response-host       "my.server.org",
              :response-port       5555})

(sockets/send-to-server! "localhost" 8082 (json/write-str request))
```

4. Check Geoserver that the layer is removed but the workspace and
   other layers still exist.