### PR TITLE
Switch from update layer group to delete and create layer group

### DIFF
--- a/src/geosync/core.clj
+++ b/src/geosync/core.clj
@@ -164,11 +164,11 @@
                     (if (contains? existing-layer-groups name)
                       (let [old-matching-layers (seq (filterv #(s/includes? % layer-pattern)
                                                               old-layer-names))]
-                        (rest/update-layer-group geoserver-workspace
+                        (rest/delete-layer-group geoserver-workspace name)
+                        (rest/create-layer-group geoserver-workspace
                                                  name
                                                  "SINGLE"
                                                  name
-                                                 ""
                                                  ""
                                                  []
                                                  (sort (concat old-matching-layers new-matching-layers))


### PR DESCRIPTION
## Purpose
Provides a fix for #55. Instead of calling `update-layer-group`, we manually call `delete-layer-group` and then `create-layer-group` to avoid a race condition that was being thrown.
  

