### PR TITLE
Fix parse-workspace in file-watcher.clj

### DIFF
--- a/src/geosync/file_watcher.clj
+++ b/src/geosync/file_watcher.clj
@@ -106,9 +106,10 @@
   (let [folder-regex (re-pattern (format "(?<=%s/)[\\w-]+" dir))
         folder-name  (re-find folder-regex path)]
     (when-let [regex (get folder-name->regex folder-name)]
-      (some-> (re-find regex path)
-              (s/replace "_" "-")
-              (s/replace "/" "_")))))
+      (let [init-workspace       (re-find regex path)
+            [forecast timestamp] (s/split init-workspace #"/")
+            cleaned-forecast     (s/replace forecast "_" "-")]
+        (s/join "_" [cleaned-forecast timestamp])))))
 
 (defn- process-event
   [{:keys [job-queue] :as config} event-type path]


### PR DESCRIPTION
## Purpose
Fixes an issue where paths such as `/srv/gis/fire_risk_forecast/20220922_12` were yielding a workspace name of `fire-risk-forecast_20220922-12` when the actual GeoServer workspace name is `fire-risk-forecast_20220922_12`. Thus, the underscores in the forecast start time portion of the workspace name need to be kept as-is in the `parse-workspace` function.

This bug meant that the proper workspace wasn't being deleted (since it wasn't found) upon a `:delete` event.
