### PR TITLE
Small improvements to the file watcher

### DIFF
--- a/src/geosync/core.clj
+++ b/src/geosync/core.clj
@@ -192,7 +192,10 @@
         (.setProperty attribute value)
         (.store writer nil)))))
 
-(defn clean-image-mosaic-folder [data-dir]
+(defn clean-image-mosaic-folder
+  "GeoServer likes to add extra config files to an ImageMosaic directory.
+   This function deletes them (and keeps the files we care about)."
+  [data-dir]
   (doseq [file (file-seq (io/file data-dir))
           :when (let [file-name (.getName file)]
                   (not (or (.isDirectory file)

--- a/src/geosync/server.clj
+++ b/src/geosync/server.clj
@@ -150,6 +150,4 @@
   (sockets/start-server! geosync-server-port (partial handler geosync-server-host geosync-server-port))
   (process-requests! config-params)
   (when file-watcher
-    (log-str "Initializing file watcher...")
-    (file-watcher/start! config-params stand-by-queue)
-    (log-str "File watcher has been initialized.")))
+    (file-watcher/start! config-params stand-by-queue)))


### PR DESCRIPTION
## Purpose
Adding a `future` around the file watcher start function to avoid an issue with the `systemd` process restarting. 
