### PR TITLE
GEO1-79 Fix reflection warnings

### DIFF
--- a/src/geosync/core.clj
+++ b/src/geosync/core.clj
@@ -188,7 +188,7 @@
   (let [props (with-open [reader (io/reader file-path)]
                 (doto (Properties.) (.load reader)))]
     (with-open [writer (io/writer file-path)]
-      (doto props
+      (doto ^Properties props
         (.setProperty attribute value)
         (.store writer nil)))))
 
@@ -196,7 +196,7 @@
   "GeoServer likes to add extra config files to an ImageMosaic directory.
    This function deletes them (and keeps the files we care about)."
   [data-dir]
-  (doseq [file (file-seq (io/file data-dir))
+  (doseq [^File file (file-seq (io/file data-dir))
           :when (let [file-name (.getName file)]
                   (not (or (.isDirectory file)
                            (s/ends-with? file-name ".tif")

--- a/src/geosync/file_watcher.clj
+++ b/src/geosync/file_watcher.clj
@@ -60,7 +60,7 @@
              (try (reduce (fn [acc ^WatchEvent event]
                             (let [kind               (.kind event)
                                   path               (->> event
-                                                          (.context)
+                                                          ^Path (.context)
                                                           (.resolve watch-dir))
                                   updated-watch-keys (cond
                                                        (and (= kind StandardWatchEventKinds/ENTRY_CREATE)

--- a/src/geosync/simple_sockets.clj
+++ b/src/geosync/simple_sockets.clj
@@ -35,7 +35,7 @@
 
 (defn- accept-connections! [^ServerSocket server-socket handler]
   (while @global-server-thread
-    (when-let [socket (nil-on-error (.accept server-socket))]
+    (when-let [^Socket socket (nil-on-error (.accept server-socket))]
       (try
         (->> (read-socket! socket)
              (handler))


### PR DESCRIPTION
## Purpose
Fixing a few reflection warnings.

## Related Issues
Closes GEO1-79

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GEO-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
`clojure -M:check-reflection` should only show the following warning (which is from `hiccup`):
```
Reflection warning, hiccup/util.clj:101:19 - call to static method encode on java.net.URLEncoder can't be r
esolved (argument types: java.lang.String, unknown).
```

