### PR TITLE
GEO1-81 GEO1-13 Build GeoSync as an uberjar and update README

### DIFF
--- a/README.org
+++ b/README.org
@@ -325,9 +325,17 @@ echo fs.inotify.max_user_watches=$NUMBER_OF_FILES | sudo tee -a /etc/sysctl.conf
 sudo sysctl -p
 #+end_src
 
+** Uber-JAR
+
+To build GeoSync as an Uber-JAR (to the ~target~) directory, run the following:
+
+#+begin_src sh
+clojure -T:build uberjar
+#+end_src
+
 ** License and Distribution
 
-Copyright © 2020-2022 Spatial Informatics Group, LLC.
+Copyright © 2020-2023 Spatial Informatics Group, LLC.
 
 GeoSync is distributed by Spatial Informatics Group, LLC. under the
 terms of the Eclipse Public License version 2.0 (EPLv2). See

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,44 @@
+(ns build
+  (:require [clojure.tools.build.api :as b])
+  (:import java.util.Date))
+
+(defn get-calendar-branch-version []
+  (let [today  (Date.)
+        commit (b/git-process {:git-args "rev-parse --short HEAD"})]
+    (format "%d.%d.%d-%s"
+            (+ 1900 (.getYear today))
+            (+ 1 (.getMonth today))
+            (.getDate today)
+            commit)))
+
+(def build-folder "target")
+(def jar-content (str build-folder "/classes"))
+(def basis (b/create-basis {:project "deps.edn"}))
+
+(def app-name "geosync")
+(def version (get-calendar-branch-version))
+(def uberjar-file-name (format "%s/%s-%s.jar" build-folder app-name version))
+
+(defn clean [_]
+  (b/delete {:path build-folder})
+  (println (format "Build folder \"%s\" removed" build-folder)))
+
+(defn uberjar [_]
+  ;; clean up old files
+  (clean nil)
+
+  ;; copy resources to jar-content folder
+  (b/copy-dir {:src-dirs   ["src" "resources"]
+               :target-dir jar-content})
+
+  (b/compile-clj {:src-dirs  ["src"]
+                  :class-dir jar-content
+                  :basis     basis})
+
+  ;; package jar-content into a jar
+  (b/uber {:class-dir jar-content
+           :uber-file uberjar-file-name
+           :basis     basis
+           :main      'geosync.cli})
+
+  (println (format "Uberjar file created: \"%s\"" uberjar-file-name)))

--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,9 @@
            org.clojure/tools.cli        {:mvn/version "1.0.206"}
            sig-gis/triangulum           {:git/url "https://github.com/sig-gis/triangulum"
                                          :sha     "67c22ef318c8c42626186872ada4a4436c6bd405"}}
- :aliases {:build-db         {:main-opts ["-m" "triangulum.build-db"]}
+ :aliases {:build            {:deps       {io.github.clojure/tools.build {:git/tag "v0.8.2" :git/sha "ba1a2bf"}}
+                              :ns-default build}
+           :build-db         {:main-opts ["-m" "triangulum.build-db"]}
            :check-deps       {:extra-deps {olical/depot {:mvn/version "1.8.4"}}
                               :main-opts  ["-m" "depot.outdated.main"]}
            :check-reflection {:main-opts ["-e" "(do,(set!,*warn-on-reflection*,true),nil)"

--- a/src/geosync/cli.clj
+++ b/src/geosync/cli.clj
@@ -1,4 +1,5 @@
 (ns geosync.cli
+  (:gen-class)
   (:import java.util.Base64)
   (:require [clojure.edn        :as edn]
             [clojure.java.io    :as io]
@@ -182,7 +183,7 @@
 
 (def program-banner
   (str "geosync: Load a nested directory tree of GeoTIFFs and Shapefiles into a running GeoServer instance.\n"
-       "Copyright © 2020-2022 Spatial Informatics Group, LLC.\n"))
+       "Copyright © 2020-2023 Spatial Informatics Group, LLC.\n"))
 
 (defn -main
   [& args]


### PR DESCRIPTION
## Purpose
Adding a `build.clj` file to build GeoSync as an uberjar and update the README.

## Related Issues
Closes GEO1-81 GEO1-13

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `GEO-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] Feature(s) work when compiled (`clojure -M:compile-cljs`)


