### PR TITLE
Update geosync.cli/encode-str to use the Basic encoding instead of URL encoding.

### DIFF
--- a/src/geosync/cli.clj
+++ b/src/geosync/cli.clj
@@ -74,7 +74,7 @@
 
 (defn encode-str
   [s]
-  (.encodeToString (Base64/getUrlEncoder) (.getBytes ^String s)))
+  (.encodeToString (Base64/getEncoder) (.getBytes ^String s)))
 
 (defn all-required-keys? [config-params]
   (and (every? config-params [:geoserver-rest-uri :geoserver-username :geoserver-password])


### PR DESCRIPTION
-------

## Purpose
<!-- Description of what has been added/changed -->

## Related Issues
Closes GEO-###

## Submission Checklist
- [ ] Commits include the JIRA issue and the `#review` hashtag (e.g. `GEO-### #review <comment>`)
- [ ] Code passes linter rules (`clj-kondo --lint src`)
- [ ] Feature(s) work when compiled (`clojure -M:compile-cljs`)

## Testing
<!-- Create a BDD style test script -->
1. Given..., When ..., Then ....

## Screenshots
<!-- Add a screen shot when UI changes are included -->