### PR TITLE
Fix error when `style-dir` is nil

### DIFF
--- a/src/geosync/core.clj
+++ b/src/geosync/core.clj
@@ -498,10 +498,10 @@
 
 (defn load-style-file-paths
   [style-dir]
-  (->> (io/file style-dir)
-       (file-seq)
-       (filter #(s/ends-with? (.getName %) ".css"))
-       (map #(.getPath ^File %))))
+  (some->> (io/file style-dir)
+           (file-seq)
+           (filter #(s/ends-with? (.getName %) ".css"))
+           (map #(.getPath ^File %))))
 
 (defn load-gis-file-paths
   [data-dir]


### PR DESCRIPTION
## Purpose

Fix error when `style-dir` is nil

## Related Issues
Closes GEO1-###

## Submission Checklist
- [ ] Included Jira issue in the PR title (e.g. `GEO1-### Did something here`)
- [ ] Code passes linter rules (`clj-kondo --lint src`)
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
<!-- Create a BDD style test script -->
1. Given..., When ..., Then ....
