### PR TITLE
PYR1-965 Adding data security functionality

### DIFF
--- a/README.org
+++ b/README.org
@@ -423,8 +423,13 @@ Examples:
 
 ** Layer Rules
 
-*** :layer
+*** :layer-rules
 [[https://docs.geoserver.org/stable/en/user/security/layer.html][some text]]
+
+TODO expand on this
+each workspace-regex string is expected to be unique (mutually exclusive from all others)
+Multiple roles can be provided in this string, separated by commas (e.g. "ROLE_ONE,ROLE_TWO").
+Mention that when workspaces are removed, any associated layer rules are also deleted
 
 ** Using Custom Projections
 

--- a/README.org
+++ b/README.org
@@ -383,8 +383,9 @@ When using this option, styles will be created on GeoServer with their name prep
 with the workspace name, using ~:~ as separator. Example, if your workspace is named
 ~sierra-nevada~ and your style ~habitat-connectivity~, the final style name will be
 ~sierra-nevada:habitat-connectivity~. This is because GeoServer has a long standing
-[[https://osgeo-org.atlassian.net/browse/GEOS-9166][bug]] that will prevent it from assigning the correctly style if have multiple styles
-with the same name (even across different workspaces).
+[[https://osgeo-org.atlassian.net/browse/GEOS-9166][bug]] that will prevent it from
+assigning the correct style if you have multiple styles with the same name
+(even across different workspaces).
 
 *** :overwrite-styles
 If you wish to overwrite any already existing GeoServer styles with updates to the
@@ -534,7 +535,7 @@ sudo sysctl -p
 
 In server-mode, you may optionally specify [[https://docs.geoserver.org/stable/en/user/security/layer.html][layer rules]]
 associated with specific workspaces to add to GeoServer. To do so, you must provide
-a ~:layer-rules~ key value pair to your GeoSync confg file. The ~:layer-rules~ key
+a ~:layer-rules~ key value pair to your GeoSync config file. The ~:layer-rules~ key
 expects a vector of maps as its value, where each map contains a GeoServer workspace
 regex and a vector of maps of layer rules to add whenever that workspace regex
 is matched upon adding a new workpace. Each ~:workspace-regex~ is assumed to be
@@ -546,7 +547,7 @@ Note that currently the only layer rules that can be added are those that are
 associated with a specific workspace. Rules associated with global layer groups
 are not supported at this time. If you wish to add a layer rule associated with every workspace (by
 using the wildcard ~*~ character), you can do so manually via the Data Security
-page on the GeoServer web UI. Each ~:layer-rule~ inide of the ~:associated-rules~
+page on the GeoServer web UI. Each ~:layer-rule~ inside of the ~:associated-rules~
 vector of maps *must* contain "geoserver-workspace" as the beginning portion of the
 layer rule. This is replaced by the actual GeoServer workspace being added by GeoSync.
 The ~:role~ associated with each ~:layer-rule~ can contain multiple roles by separating

--- a/README.org
+++ b/README.org
@@ -427,6 +427,7 @@ Examples:
 [[https://docs.geoserver.org/stable/en/user/security/layer.html][some text]]
 
 TODO expand on this
+Only for layer rules that start with a GeoServer workspace at this time
 each workspace-regex string is expected to be unique (mutually exclusive from all others)
 Multiple roles can be provided in this string, separated by commas (e.g. "ROLE_ONE,ROLE_TWO").
 Mention that when workspaces are removed, any associated layer rules are also deleted

--- a/README.org
+++ b/README.org
@@ -421,17 +421,6 @@ Examples:
 | SierraNevada_Tier2_AnnualBurnProbability | sierra-nevada:TIER1_ANNUALBURNPROBABILITY | N      |
 |------------------------------------------+-------------------------------------------+--------|
 
-** Layer Rules
-
-*** :layer-rules
-[[https://docs.geoserver.org/stable/en/user/security/layer.html][some text]]
-
-TODO expand on this
-Only for layer rules that start with a GeoServer workspace at this time
-each workspace-regex string is expected to be unique (mutually exclusive from all others)
-Multiple roles can be provided in this string, separated by commas (e.g. "ROLE_ONE,ROLE_TWO").
-Mention that when workspaces are removed, any associated layer rules are also deleted
-
 ** Using Custom Projections
 
 If your GIS data uses a custom projection that is not known to the
@@ -540,6 +529,34 @@ To make this limit permanent, run:
 echo fs.inotify.max_user_watches=$NUMBER_OF_FILES | sudo tee -a /etc/sysctl.conf
 sudo sysctl -p
 #+end_src
+
+** Layer Rules
+
+*** :layer-rules
+
+In server-mode, you may optionally specify [[https://docs.geoserver.org/stable/en/user/security/layer.html][layer rules]]
+associated with specific workspaces to add to GeoServer. To do so, you must provide
+a ~:layer-rules~ key value pair to your GeoSync confg file. The ~:layer-rules~ key
+expects a vector of maps as its value, where each map contains a GeoServer workspace
+regex and a vector of maps of layer rules to add whenever that workspace regex
+is matched upon adding a new workpace. Each ~:workspace-regex~ is assumed to be
+unique from every other ~:workspace-regex~ because you can add as many ~:associated-rules~
+as you like to each regex. For an example of what this looks like,
+see [[file:resources/sample-config.edn][resources/sample-config.edn]].
+
+Note that currently the only layer rules that can be added are those that are
+associated with a specific workspace. Global layer groups are not supported at
+this time. If you wish to add a layer rule associated with every workspace (by
+using the wildcard ~*~ character), you can do so manually via the Data Security
+page on the GeoServer web UI. Each ~:layer-rule~ inide of the ~:associated-rules~
+vector of maps *must* contain ~"geoserver-workspace"~ as the beginning part of the
+layer rule. This is replaced by the actual GeoServer workspace being added by GeoSync.
+The ~:role~ associated with each ~:layer-rule~ can contain multiple roles by separating
+each role with a comma (e.g. ~"ROLE_ONE,ROLE_TWO"~).
+
+When a workspace is removed, all existing layer rules are compared to the workspace
+being removed. Each existing layer rule that applies to the workspace being removed
+is deleted from GeoServer in order to clean up after ourselves.
 
 ** UberJAR
 

--- a/README.org
+++ b/README.org
@@ -532,8 +532,6 @@ sudo sysctl -p
 
 ** Layer Rules
 
-*** :layer-rules
-
 In server-mode, you may optionally specify [[https://docs.geoserver.org/stable/en/user/security/layer.html][layer rules]]
 associated with specific workspaces to add to GeoServer. To do so, you must provide
 a ~:layer-rules~ key value pair to your GeoSync confg file. The ~:layer-rules~ key
@@ -545,18 +543,18 @@ as you like to each regex. For an example of what this looks like,
 see [[file:resources/sample-config.edn][resources/sample-config.edn]].
 
 Note that currently the only layer rules that can be added are those that are
-associated with a specific workspace. Global layer groups are not supported at
-this time. If you wish to add a layer rule associated with every workspace (by
+associated with a specific workspace. Rules associated with global layer groups
+are not supported at this time. If you wish to add a layer rule associated with every workspace (by
 using the wildcard ~*~ character), you can do so manually via the Data Security
 page on the GeoServer web UI. Each ~:layer-rule~ inide of the ~:associated-rules~
-vector of maps *must* contain ~"geoserver-workspace"~ as the beginning part of the
+vector of maps *must* contain "geoserver-workspace" as the beginning portion of the
 layer rule. This is replaced by the actual GeoServer workspace being added by GeoSync.
 The ~:role~ associated with each ~:layer-rule~ can contain multiple roles by separating
-each role with a comma (e.g. ~"ROLE_ONE,ROLE_TWO"~).
+each role with a comma (e.g. "ROLE_ONE,ROLE_TWO").
 
 When a workspace is removed, all existing layer rules are compared to the workspace
 being removed. Each existing layer rule that applies to the workspace being removed
-is deleted from GeoServer in order to clean up after ourselves.
+is deleted from GeoServer along with the workspace.
 
 ** UberJAR
 

--- a/README.org
+++ b/README.org
@@ -533,7 +533,7 @@ sudo sysctl -p
 
 ** Layer Rules
 
-In server-mode, you may optionally specify [[https://docs.geoserver.org/stable/en/user/security/layer.html][layer rules]]
+You may optionally specify [[https://docs.geoserver.org/stable/en/user/security/layer.html][layer rules]]
 associated with specific workspaces to add to GeoServer. To do so, you must provide
 a ~:layer-rules~ key value pair to your GeoSync config file. The ~:layer-rules~ key
 expects a vector of maps as its value, where each map contains a GeoServer workspace

--- a/README.org
+++ b/README.org
@@ -381,7 +381,7 @@ both be added under the same ~:geoserver-workspace~.
 
 When using this option, styles will be created on GeoServer with their name prepended
 with the workspace name, using ~:~ as separator. Example, if your workspace is named
-~sierra-nevada~ and your style ~habitat-connectivity~, the final style name will be 
+~sierra-nevada~ and your style ~habitat-connectivity~, the final style name will be
 ~sierra-nevada:habitat-connectivity~. This is because GeoServer has a long standing
 [[https://osgeo-org.atlassian.net/browse/GEOS-9166][bug]] that will prevent it from assigning the correctly style if have multiple styles
 with the same name (even across different workspaces).
@@ -406,7 +406,7 @@ you can rely on this feature to do the work for you.
 
 To use it, you must set ~autostyle-layers~ to true (using the CLI or the configuration file).
 
-GeoSync will fetch all existing styles in the specified ~geoserver-workspace~ and will match each 
+GeoSync will fetch all existing styles in the specified ~geoserver-workspace~ and will match each
 newly added GIS layer with any style whose name appears in the end of the layer name. This string
 matching is case insensitive.
 
@@ -420,6 +420,11 @@ Examples:
 | SierraNevada_Tier2_AnnualBurnProbability | sierra-nevada:TIER2_ANNUALBURNPROBABILITY | Y      |
 | SierraNevada_Tier2_AnnualBurnProbability | sierra-nevada:TIER1_ANNUALBURNPROBABILITY | N      |
 |------------------------------------------+-------------------------------------------+--------|
+
+** Layer Rules
+
+*** :layer
+[[https://docs.geoserver.org/stable/en/user/security/layer.html][some text]]
 
 ** Using Custom Projections
 

--- a/resources/sample-config.edn
+++ b/resources/sample-config.edn
@@ -13,16 +13,16 @@
  :data-dir            "/data"
  :style-dir           "/styles"
  :overwrite-styles    true
- :layer-rules         [{:workspace-regex  #"^fire-risk-forecast_liberty_\d{8}_\d{2}$"
+ :layer-rules         [{:workspace-regex  "^fire-risk-forecast_liberty_\\d{8}_\\d{2}$"
                         :associated-rules [{:layer-rule "geoserver-workspace.*.r" :role "LIBERTY"}
                                            {:layer-rule "geoserver-workspace.*.w" :role "LIBERTY"}]}
-                       {:workspace-regex  #"^psps-static_liberty$"
+                       {:workspace-regex  "^psps-static_liberty$"
                         :associated-rules [{:layer-rule "geoserver-workspace.*.r" :role "LIBERTY"}
                                            {:layer-rule "geoserver-workspace.*.w" :role "LIBERTY"}]}
-                       {:workspace-regex  #"^fire-risk-forecast_nve_\d{8}_\d{2}$"
+                       {:workspace-regex  "^fire-risk-forecast_nve_\\d{8}_\\d{2}$"
                         :associated-rules [{:layer-rule "geoserver-workspace.*.r" :role "NVE"}
                                            {:layer-rule "geoserver-workspace.*.w" :role "NVE"}]}
-                       {:workspace-regex  #"^psps-static_nve$"
+                       {:workspace-regex  "^psps-static_nve$"
                         :associated-rules [{:layer-rule "geoserver-workspace.*.r" :role "NVE,GROUP_ADMIN"}
                                            {:layer-rule "geoserver-workspace.*.w" :role "NVE,GROUP_ADMIN"}]}]
  :log-dir             "logs"

--- a/resources/sample-config.edn
+++ b/resources/sample-config.edn
@@ -23,8 +23,8 @@
                         :associated-rules [{:layer-rule "geoserver-workspace.*.r" :role "NVE"}
                                            {:layer-rule "geoserver-workspace.*.w" :role "NVE"}]}
                        {:workspace-regex  #"^psps-static_nve$"
-                        :associated-rules [{:layer-rule "geoserver-workspace.*.r" :role "NVE"}
-                                           {:layer-rule "geoserver-workspace.*.w" :role "NVE"}]}]
+                        :associated-rules [{:layer-rule "geoserver-workspace.*.r" :role "NVE,GROUP_ADMIN"}
+                                           {:layer-rule "geoserver-workspace.*.w" :role "NVE,GROUP_ADMIN"}]}]
  :log-dir             "logs"
  :styles              [{:layer-pattern "fire-area"            :raster-style "fire-area"           :vector-style "line-fire-area"}
                        {:layer-pattern "fire-volume"          :raster-style "fire-volume"         :vector-style "line-fire-volume"}

--- a/resources/sample-config.edn
+++ b/resources/sample-config.edn
@@ -13,6 +13,18 @@
  :data-dir            "/data"
  :style-dir           "/styles"
  :overwrite-styles    true
+ :layer-rules         [{:workspace-regex  #"^fire-risk-forecast_liberty_\d{8}_\d{2}$"
+                        :associated-rules [{:layer-rule "geoserver-workspace.*.r" :role "LIBERTY"}
+                                           {:layer-rule "geoserver-workspace.*.w" :role "LIBERTY"}]}
+                       {:workspace-regex  #"^psps-static_liberty$"
+                        :associated-rules [{:layer-rule "geoserver-workspace.*.r" :role "LIBERTY"}
+                                           {:layer-rule "geoserver-workspace.*.w" :role "LIBERTY"}]}
+                       {:workspace-regex  #"^fire-risk-forecast_nve_\d{8}_\d{2}$"
+                        :associated-rules [{:layer-rule "geoserver-workspace.*.r" :role "NVE"}
+                                           {:layer-rule "geoserver-workspace.*.w" :role "NVE"}]}
+                       {:workspace-regex  #"^psps-static_nve$"
+                        :associated-rules [{:layer-rule "geoserver-workspace.*.r" :role "NVE"}
+                                           {:layer-rule "geoserver-workspace.*.w" :role "NVE"}]}]
  :log-dir             "logs"
  :styles              [{:layer-pattern "fire-area"            :raster-style "fire-area"           :vector-style "line-fire-area"}
                        {:layer-pattern "fire-volume"          :raster-style "fire-volume"         :vector-style "line-fire-volume"}

--- a/src/geosync/cli.clj
+++ b/src/geosync/cli.clj
@@ -52,7 +52,7 @@
 (spec/def ::folder-name->regex  (spec/map-of string? string?))
 (spec/def ::file-watcher        (spec/keys :req-un [::dir
                                                     ::folder-name->regex]))
-(spec/def ::workspace-regex     re-pattern)
+(spec/def ::workspace-regex     non-empty-string?)
 (spec/def ::associated-rule     (spec/keys :req-un [::layer-rule ::role]))
 (spec/def ::associated-rules    (spec/coll-of ::associated-rule :kind vector? :distinct true))
 (spec/def ::one-layer-rule      (spec/keys :req-un [::workspace-regex ::associated-rules]))

--- a/src/geosync/cli.clj
+++ b/src/geosync/cli.clj
@@ -52,8 +52,11 @@
 (spec/def ::folder-name->regex  (spec/map-of string? string?))
 (spec/def ::file-watcher        (spec/keys :req-un [::dir
                                                     ::folder-name->regex]))
-(spec/def ::workspace-regex     non-empty-string?)
+(spec/def ::layer-rule          #(and (s/starts-with? % "geoserver-workspace.")
+                                      (= 3 (count (s/split % #"\.")))))
+(spec/def ::role                non-empty-string?)
 (spec/def ::associated-rule     (spec/keys :req-un [::layer-rule ::role]))
+(spec/def ::workspace-regex     non-empty-string?)
 (spec/def ::associated-rules    (spec/coll-of ::associated-rule :kind vector? :distinct true))
 (spec/def ::one-layer-rule      (spec/keys :req-un [::workspace-regex ::associated-rules]))
 (spec/def ::layer-rules         (spec/coll-of ::one-layer-rule :kind vector? :distinct true))

--- a/src/geosync/cli.clj
+++ b/src/geosync/cli.clj
@@ -52,6 +52,11 @@
 (spec/def ::folder-name->regex  (spec/map-of string? string?))
 (spec/def ::file-watcher        (spec/keys :req-un [::dir
                                                     ::folder-name->regex]))
+(spec/def ::workspace-regex     re-pattern)
+(spec/def ::associated-rule     (spec/keys :req-un [::layer-rule ::role]))
+(spec/def ::associated-rules    (spec/coll-of ::associated-rule :kind vector? :distinct true))
+(spec/def ::one-layer-rule      (spec/keys :req-un [::workspace-regex ::associated-rules]))
+(spec/def ::layer-rules         (spec/coll-of ::one-layer-rule :kind vector? :distinct true))
 (spec/def ::geosync-config-file (spec/keys :opt-un [::geoserver-rest-uri
                                                     ::geoserver-username
                                                     ::geoserver-password
@@ -66,7 +71,8 @@
                                                     ::layer-groups
                                                     ::styles
                                                     ::action-hooks
-                                                    ::file-watcher]))
+                                                    ::file-watcher
+                                                    ::layer-rules]))
 
 ;; Key Combination Rules
 

--- a/src/geosync/core.clj
+++ b/src/geosync/core.clj
@@ -686,7 +686,7 @@
                                                     (:status)
                                                     (success-code?))
                     existing-layer-rules      (when layer-rules?
-                                                (get-existing-layer-rules (:layer-rules config-params)))
+                                                (get-existing-layer-rules config-params))
                     layer-rules-to-delete     (->> existing-layer-rules
                                                    (filter #(let [[rule-workspace _ _] (s/split (:layer-rule %) #"\.")]
                                                               (= rule-workspace current-workspace)))
@@ -698,7 +698,7 @@
                                                                                       (:status)
                                                                                       (success-code?))
                                                                                 layer-rules-to-delete)]
-                                                   (every? true? request-success-vec)))]
+                                                   (every? some? request-success-vec)))]
                 (when (and layer-rules? delete-layer-rule-success?)
                   (log (str (count layer-rules-to-delete) " layer rules were removed.")))
                 (and delete-workspace-success? delete-layer-rule-success? acc)))

--- a/src/geosync/core.clj
+++ b/src/geosync/core.clj
@@ -6,7 +6,6 @@
   (:require [clj-http.client     :as client]
             [clojure.data.json   :as json]
             [clojure.java.io     :as io]
-            [clojure.set         :as set]
             [clojure.string      :as s]
             [geosync.rest-api    :as rest]
             [geosync.utils       :refer [nil-on-error url-path]]
@@ -443,7 +442,7 @@
                                              existing-layer-rules))
                                      matching-layer-rules)]
     (if-not (empty? final-layer-rules)
-      (rest/add-layer-rules final-layer-rules)
+      [(rest/add-layer-rules final-layer-rules)]
       nil)))
 
 (defn file-specs->rest-specs
@@ -700,7 +699,7 @@
                                                                                       (success-code?))
                                                                                 layer-rules-to-delete)]
                                                    (every? true? request-success-vec)))]
-                (when delete-layer-rule-success?
+                (when (and layer-rules? delete-layer-rule-success?)
                   (log (str (count layer-rules-to-delete) " layer rules were removed.")))
                 (and delete-workspace-success? delete-layer-rule-success? acc)))
             true

--- a/src/geosync/core.clj
+++ b/src/geosync/core.clj
@@ -423,7 +423,7 @@
    in the `:layer-rules` entry, thus it's safe to call `first` on the matching regex."
   [geoserver-workspace layer-rules]
   (some->> layer-rules
-    (filter #(re-matches (:workspace-regex %) geoserver-workspace))
+    (filter #(re-matches (re-pattern (:workspace-regex %)) geoserver-workspace))
     (first)
     (:associated-rules)
     (map (fn [rule]

--- a/src/geosync/rest_api.clj
+++ b/src/geosync/rest_api.clj
@@ -843,12 +843,13 @@
    (str "/security/acl/layers/" layer-rule)])
 
 (defn add-layer-rules
-  [layer-rules role]
+  [layer-rules]
   ["POST"
    "/security/acl/layers"
    (xml
     [:rules
-     (map (fn [layer-rule] [:rule {:resource layer-rule} role])
+     (map (fn [{:keys [layer-rule role]}]
+            [:rule {:resource layer-rule} role])
           layer-rules)])])
 
 (defn get-layer-rules

--- a/src/geosync/rest_api.clj
+++ b/src/geosync/rest_api.clj
@@ -837,10 +837,11 @@
 ;;
 ;;=================================================================================
 
-(defn delete-layer-rule
-  [layer-rule]
-  ["DELETE"
-   (str "/security/acl/layers/" layer-rule)])
+(defn get-layer-rules
+  []
+  ["GET"
+   "/security/acl/layers"
+   nil])
 
 (defn add-layer-rules
   [layer-rules]
@@ -852,7 +853,8 @@
             [:rule {:resource layer-rule} role])
           layer-rules)])])
 
-(defn get-layer-rules
-  []
-  ["GET"
-   "/security/acl/layers"])
+(defn delete-layer-rule
+  [layer-rule]
+  ["DELETE"
+   (str "/security/acl/layers/" layer-rule)
+   nil])

--- a/src/geosync/rest_api.clj
+++ b/src/geosync/rest_api.clj
@@ -830,3 +830,28 @@
        [:normalize
         [:locale ""]]]]])
    "application/xml"])
+
+;;=================================================================================
+;;
+;; Security (https://docs.geoserver.org/latest/en/api/#1.0.0/security.yaml)
+;;
+;;=================================================================================
+
+(defn delete-layer-rule
+  [layer-rule]
+  ["DELETE"
+   (str "/security/acl/layers/" layer-rule)])
+
+(defn add-layer-rules
+  [layer-rules role]
+  ["POST"
+   "/security/acl/layers"
+   (xml
+    [:rules
+     (map (fn [layer-rule] [:rule {:resource layer-rule} role])
+          layer-rules)])])
+
+(defn get-layer-rules
+  []
+  ["GET"
+   "/security/acl/layers"])


### PR DESCRIPTION
## Purpose
Extends GeoSync such that you can [add and remove layer rules](https://docs.geoserver.org/stable/en/user/security/layer.html) automatically by providing a `:layer-rules` key in your `config.edn` file. When a new workspace is added, each `:workspace-regex` inside of the `:layer-rules` map is checked against that workspace. Each `:workspace-regex` is assumed to be unique from every other `:workspace-regex`. This is because you can add as many `:associated-rules` as you like to each regex.

Once a matching `:workspace-regex` is found, GeoSync will add each entry in the `:associated-rules` map that doesn't already have an existing role on the GeoServer. Note that each `:layer-rule` **must** contain `geoserver-workspace` as the beginning part of the layer rule. This is replaced by the actual GeoServer workspace being added by GeoSync. 

When a workspace is removed, all existing layer rules are compared to the workspace being removed. Each existing layer rule that applies to the workspace being removed is deleted from the GeoServer in order to clean up after ourselves.

## Related Issues
Closes PYR1-965

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `GEO1-### Did something here`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] No new reflection warnings (`clojure -M:check-reflection`)
