### PR TITLE
Implement all of the "Data Rules" and "Admin Rules" GeoFence REST API functions

### DIFF
--- a/src/geosync/core.clj
+++ b/src/geosync/core.clj
@@ -93,13 +93,14 @@
 
 ;; FIXME: Use an SSL keystore and remove insecure? param
 (defn make-rest-request
-  [{:keys [geoserver-rest-uri geoserver-rest-headers]} [http-method uri-suffix http-body content-type]]
+  [{:keys [geoserver-rest-uri geoserver-rest-headers]} [http-method uri-suffix http-body content-type accept]]
   (try
-    (let [response (client/request {:url                (url-path geoserver-rest-uri uri-suffix)
+    (let [headers  (cond-> geoserver-rest-headers
+                     content-type (assoc "Content-Type" content-type)
+                     accept       (assoc "Accept" accept))
+          response (client/request {:url                (url-path geoserver-rest-uri uri-suffix)
                                     :method             http-method
-                                    :headers            (if content-type
-                                                          (assoc geoserver-rest-headers "Content-Type" content-type)
-                                                          geoserver-rest-headers)
+                                    :headers            headers
                                     :body               http-body
                                     :insecure?          true
                                     :socket-timeout     timeout-ms
@@ -122,13 +123,14 @@
 
 ;; FIXME: Use an SSL keystore and remove insecure? param
 (defn make-rest-request-async
-  [{:keys [geoserver-rest-uri geoserver-rest-headers]} [http-method uri-suffix http-body content-type]]
-  (let [result (promise)]
+  [{:keys [geoserver-rest-uri geoserver-rest-headers]} [http-method uri-suffix http-body content-type accept]]
+  (let [result  (promise)
+        headers (cond-> geoserver-rest-headers
+                  content-type (assoc "Content-Type" content-type)
+                  accept       (assoc "Accept" accept))]
     (client/request {:url                (url-path geoserver-rest-uri uri-suffix)
                      :method             http-method
-                     :headers            (if content-type
-                                           (assoc geoserver-rest-headers "Content-Type" content-type)
-                                           geoserver-rest-headers)
+                     :headers            headers
                      :body               http-body
                      :insecure?          true
                      :async?             true

--- a/src/geosync/rest_api.clj
+++ b/src/geosync/rest_api.clj
@@ -877,9 +877,11 @@
    (str "/geofence/rules/id/" rule-id)
    nil])
 
+;; FIXME: (assoc-in config-params [:geoserver-rest-headers "Accept"] "*/*")
 ;; NOTE: This function doesn't implement the <subfield>, <limits>, or <layerDetails> entries.
 (defn add-geofence-rule [& {:keys [priority user-name role-name address-range valid-after valid-before
                                    service request workspace layer access]}]
+  {:pre [(contains? #{"ALLOW" "DENY"} access)]}
   ["POST"
    "/geofence/rules"
    (xml
@@ -913,7 +915,7 @@
        request       (conj [:request request])            ; OGC request name  : GetMap
        workspace     (conj [:workspace workspace])        ; workspace name    : super-private-workspace
        layer         (conj [:layer layer])                ; layer name        : ultra-secret-layer
-       access        (conj [:access access])))])
+       access        (conj [:access access])))])          ; ALLOW | DENY      : ALLOW
 
 (defn delete-geofence-rule [rule-id]
   ["DELETE"
@@ -942,6 +944,7 @@
    nil])
 
 (defn add-geofence-admin-rule [& {:keys [priority user-name role-name address-range workspace access]}]
+  {:pre [(contains? #{"ADMIN" "USER"} access)]}
   ["POST"
    "/geofence/adminrules"
    (xml
@@ -951,8 +954,9 @@
        role-name     (conj [:roleName role-name])         ; string            : ADVENTURER
        address-range (conj [:addressRange address-range]) ; IPV4 CIDR notation: 192.168.0.0/16
        workspace     (conj [:workspace workspace])        ; workspace name    : super-private-workspace
-       access        (conj [:access access])))])          ; ALLOW | DENY      : ALLOW
+       access        (conj [:access access])))])          ; ADMIN | USER      : ADMIN
 
+;; FIXME: (assoc-in config-params [:geoserver-rest-headers "Accept"] "*/*")
 (defn update-geofence-admin-rule [rule-id & {:keys [priority user-name role-name address-range workspace access]}]
   ["POST"
    (str "/geofence/adminrules/id/" rule-id)
@@ -963,7 +967,7 @@
        role-name     (conj [:roleName role-name])         ; string            : ADVENTURER
        address-range (conj [:addressRange address-range]) ; IPV4 CIDR notation: 192.168.0.0/16
        workspace     (conj [:workspace workspace])        ; workspace name    : super-private-workspace
-       access        (conj [:access access])))])          ; ALLOW | DENY      : ALLOW
+       access        (conj [:access access])))])          ; ADMIN | USER      : ADMIN
 
 (defn delete-geofence-admin-rule [rule-id]
   ["DELETE"

--- a/src/geosync/rest_api.clj
+++ b/src/geosync/rest_api.clj
@@ -5,11 +5,11 @@
   (:require [clojure.string :as s]
             [geosync.utils  :refer [xml extract-georeferences]]))
 
-;;=================================================================================
+;;===============================================================================================================
 ;;
 ;; Workspaces (http://docs.geoserver.org/latest/en/api/#1.0.0/workspaces.yaml)
 ;;
-;;=================================================================================
+;;===============================================================================================================
 
 (defn get-workspaces []
   ["GET"
@@ -41,11 +41,11 @@
    (str "/workspaces/" workspace "?recurse=" recurse?)
    nil])
 
-;;=================================================================================
+;;===============================================================================================================
 ;;
 ;; Namespaces (http://docs.geoserver.org/latest/en/api/#1.0.0/namespaces.yaml)
 ;;
-;;=================================================================================
+;;===============================================================================================================
 
 (defn get-namespaces []
   ["GET"
@@ -79,11 +79,11 @@
    (str "/namespaces/" workspace)
    nil])
 
-;;=================================================================================
+;;===============================================================================================================
 ;;
 ;; Data Stores (http://docs.geoserver.org/latest/en/api/#1.0.0/datastores.yaml)
 ;;
-;;=================================================================================
+;;===============================================================================================================
 
 (defn get-data-stores [workspace]
   ["GET"
@@ -160,11 +160,11 @@
    (str "/workspaces/" workspace "/datastores/" store)
    nil])
 
-;;=================================================================================
+;;===============================================================================================================
 ;;
 ;; Coverage Stores (http://docs.geoserver.org/latest/en/api/#1.0.0/coveragestores.yaml)
 ;;
-;;=================================================================================
+;;===============================================================================================================
 
 (defn get-coverage-stores [workspace]
   ["GET"
@@ -216,11 +216,11 @@
    (str "/workspaces/" workspace "/coveragestores/" store)
    nil])
 
-;;=================================================================================
+;;===============================================================================================================
 ;;
 ;; Feature Types (http://docs.geoserver.org/latest/en/api/#1.0.0/featuretypes.yaml)
 ;;
-;;=================================================================================
+;;===============================================================================================================
 
 (defn get-feature-types
   ([workspace]
@@ -302,11 +302,11 @@
    (str "/workspaces/" workspace "/datastores/" store "/featuretypes/" feature-type)
    nil])
 
-;;=================================================================================
+;;===============================================================================================================
 ;;
 ;; Coverages (http://docs.geoserver.org/latest/en/api/#1.0.0/coverages.yaml)
 ;;
-;;=================================================================================
+;;===============================================================================================================
 
 (defn get-coverages
   ([workspace]
@@ -508,11 +508,11 @@
    (str "/workspaces/" workspace "/coveragestores/" store "/coverages/" coverage)
    nil])
 
-;;=================================================================================
+;;===============================================================================================================
 ;;
 ;; Layers (https://docs.geoserver.org/latest/en/api/#1.0.0/layers.yaml)
 ;;
-;;=================================================================================
+;;===============================================================================================================
 
 (defn get-layers
   ([]
@@ -616,11 +616,11 @@
     (str "/workspaces/" workspace "/layers/" layer)
     nil]))
 
-;;=================================================================================
+;;===============================================================================================================
 ;;
 ;; Layer Groups (http://docs.geoserver.org/latest/en/api/#1.0.0/layergroups.yaml)
 ;;
-;;=================================================================================
+;;===============================================================================================================
 
 (defn get-layer-groups
   ([]
@@ -722,11 +722,11 @@
     (str "/workspaces/" workspace "/layergroups/" layer-group)
     nil]))
 
-;;=================================================================================
+;;===============================================================================================================
 ;;
 ;; Styles (http://docs.geoserver.org/latest/en/api/#1.0.0/styles.yaml)
 ;;
-;;=================================================================================
+;;===============================================================================================================
 
 (defn get-styles
   ([]
@@ -782,11 +782,11 @@
     (str "/workspaces/" workspace "/styles/" style)
     nil]))
 
-;;=================================================================================
+;;===============================================================================================================
 ;;
 ;; GeoWebCache (http://docs.geoserver.org/latest/en/api/#1.0.0/gwclayers.yaml)
 ;;
-;;=================================================================================
+;;===============================================================================================================
 
 (defn get-cached-layer [workspace layer]
   ["GET"
@@ -831,20 +831,18 @@
         [:locale ""]]]]])
    "application/xml"])
 
-;;=================================================================================
+;;===============================================================================================================
 ;;
 ;; Security (https://docs.geoserver.org/latest/en/api/#1.0.0/security.yaml)
 ;;
-;;=================================================================================
+;;===============================================================================================================
 
-(defn get-layer-rules
-  []
+(defn get-layer-rules []
   ["GET"
    "/security/acl/layers"
    nil])
 
-(defn add-layer-rules
-  [layer-rules]
+(defn add-layer-rules [layer-rules]
   ["POST"
    "/security/acl/layers"
    (xml
@@ -853,8 +851,121 @@
             [:rule {:resource layer-rule} role])
           layer-rules)])])
 
-(defn delete-layer-rule
-  [layer-rule]
+(defn delete-layer-rule [layer-rule]
   ["DELETE"
    (str "/security/acl/layers/" layer-rule)
+   nil])
+
+;;===============================================================================================================
+;;
+;; GeoFence Rules (https://docs.geoserver.org/main/en/user/extensions/geofence-server/rest.html)
+;;
+;;===============================================================================================================
+
+(defn count-geofence-rules []
+  ["GET"
+   "/geofence/rules/count"
+   nil])
+
+(defn get-geofence-rules []
+  ["GET"
+   "/geofence/rules"
+   nil])
+
+(defn get-geofence-rule [rule-id]
+  ["GET"
+   (str "/geofence/rules/id/" rule-id)
+   nil])
+
+;; NOTE: This function doesn't implement the <subfield>, <limits>, or <layerDetails> entries.
+(defn add-geofence-rule [& {:keys [priority user-name role-name address-range valid-after valid-before
+                                   service request workspace layer access]}]
+  ["POST"
+   "/geofence/rules"
+   (xml
+     (cond-> [:Rule]
+       priority      (conj [:priority priority])          ; integer           : 1
+       user-name     (conj [:userName user-name])         ; string            : john_smith
+       role-name     (conj [:roleName role-name])         ; string            : ADVENTURER
+       address-range (conj [:addressRange address-range]) ; IPV4 CIDR notation: 192.168.0.0/16
+       valid-after   (conj [:validAfter valid-after])     ; yyyy-MM-dd        : 2025-02-01
+       valid-before  (conj [:validBefore valid-before])   ; yyyy-MM-dd        : 2025-02-28
+       service       (conj [:service service])            ; OGC service name  : WMS
+       request       (conj [:request request])            ; OGC request name  : GetMap
+       workspace     (conj [:workspace workspace])        ; workspace name    : super-private-workspace
+       layer         (conj [:layer layer])                ; layer name        : ultra-secret-layer
+       access        (conj [:access access])))])          ; ALLOW | DENY      : ALLOW
+
+;; NOTE: This function doesn't implement the <subfield>, <limits>, or <layerDetails> entries.
+(defn update-geofence-rule [rule-id & {:keys [priority user-name role-name address-range valid-after valid-before
+                                              service request workspace layer access]}]
+  ["POST"
+   (str "/geofence/rules/id/" rule-id)
+   (xml
+     (cond-> [:Rule]
+       priority      (conj [:priority priority])          ; integer           : 1
+       user-name     (conj [:userName user-name])         ; string            : john_smith
+       role-name     (conj [:roleName role-name])         ; string            : ADVENTURER
+       address-range (conj [:addressRange address-range]) ; IPV4 CIDR notation: 192.168.0.0/16
+       valid-after   (conj [:validAfter valid-after])     ; yyyy-MM-dd        : 2025-02-01
+       valid-before  (conj [:validBefore valid-before])   ; yyyy-MM-dd        : 2025-02-28
+       service       (conj [:service service])            ; OGC service name  : WMS
+       request       (conj [:request request])            ; OGC request name  : GetMap
+       workspace     (conj [:workspace workspace])        ; workspace name    : super-private-workspace
+       layer         (conj [:layer layer])                ; layer name        : ultra-secret-layer
+       access        (conj [:access access])))])
+
+(defn delete-geofence-rule [rule-id]
+  ["DELETE"
+   (str "/geofence/rules/id/" rule-id)
+   nil])
+
+;;===============================================================================================================
+;;
+;; GeoFence Admin Rules (https://docs.geoserver.org/main/en/user/extensions/geofence-server/rest-adminrule.html)
+;;
+;;===============================================================================================================
+
+(defn count-geofence-admin-rules []
+  ["GET"
+   "/geofence/adminrules/count"
+   nil])
+
+(defn get-geofence-admin-rules []
+  ["GET"
+   "/geofence/adminrules"
+   nil])
+
+(defn get-geofence-admin-rule [rule-id]
+  ["GET"
+   (str "/geofence/adminrules/id/" rule-id)
+   nil])
+
+(defn add-geofence-admin-rule [& {:keys [priority user-name role-name address-range workspace access]}]
+  ["POST"
+   "/geofence/adminrules"
+   (xml
+     (cond-> [:AdminRule]
+       priority      (conj [:priority priority])          ; integer           : 1
+       user-name     (conj [:userName user-name])         ; string            : john_smith
+       role-name     (conj [:roleName role-name])         ; string            : ADVENTURER
+       address-range (conj [:addressRange address-range]) ; IPV4 CIDR notation: 192.168.0.0/16
+       workspace     (conj [:workspace workspace])        ; workspace name    : super-private-workspace
+       access        (conj [:access access])))])          ; ALLOW | DENY      : ALLOW
+
+(defn update-geofence-admin-rule [rule-id & {:keys [priority user-name role-name address-range workspace access]}]
+  ["POST"
+   (str "/geofence/adminrules/id/" rule-id)
+   (xml
+     (cond-> [:AdminRule]
+       priority      (conj [:priority priority])          ; integer           : 1
+       user-name     (conj [:userName user-name])         ; string            : john_smith
+       role-name     (conj [:roleName role-name])         ; string            : ADVENTURER
+       address-range (conj [:addressRange address-range]) ; IPV4 CIDR notation: 192.168.0.0/16
+       workspace     (conj [:workspace workspace])        ; workspace name    : super-private-workspace
+       access        (conj [:access access])))])          ; ALLOW | DENY      : ALLOW
+
+(defn delete-geofence-admin-rule [rule-id]
+  ["DELETE"
+   (str "/geofence/adminrules/id/" rule-id)
    nil])

--- a/src/geosync/rest_api.clj
+++ b/src/geosync/rest_api.clj
@@ -877,7 +877,6 @@
    (str "/geofence/rules/id/" rule-id)
    nil])
 
-;; FIXME: (assoc-in config-params [:geoserver-rest-headers "Accept"] "*/*")
 ;; NOTE: This function doesn't implement the <subfield>, <limits>, or <layerDetails> entries.
 (defn add-geofence-rule [& {:keys [priority user-name role-name address-range valid-after valid-before
                                    service request workspace layer access]}]
@@ -896,7 +895,9 @@
        request       (conj [:request request])            ; OGC request name  : GetMap
        workspace     (conj [:workspace workspace])        ; workspace name    : super-private-workspace
        layer         (conj [:layer layer])                ; layer name        : ultra-secret-layer
-       access        (conj [:access access])))])          ; ALLOW | DENY      : ALLOW
+       access        (conj [:access access])))            ; ALLOW | DENY      : ALLOW
+   nil
+   "*/*"])
 
 ;; NOTE: This function doesn't implement the <subfield>, <limits>, or <layerDetails> entries.
 (defn update-geofence-rule [rule-id & {:keys [priority user-name role-name address-range valid-after valid-before
@@ -956,7 +957,6 @@
        workspace     (conj [:workspace workspace])        ; workspace name    : super-private-workspace
        access        (conj [:access access])))])          ; ADMIN | USER      : ADMIN
 
-;; FIXME: (assoc-in config-params [:geoserver-rest-headers "Accept"] "*/*")
 (defn update-geofence-admin-rule [rule-id & {:keys [priority user-name role-name address-range workspace access]}]
   ["POST"
    (str "/geofence/adminrules/id/" rule-id)
@@ -967,7 +967,9 @@
        role-name     (conj [:roleName role-name])         ; string            : ADVENTURER
        address-range (conj [:addressRange address-range]) ; IPV4 CIDR notation: 192.168.0.0/16
        workspace     (conj [:workspace workspace])        ; workspace name    : super-private-workspace
-       access        (conj [:access access])))])          ; ADMIN | USER      : ADMIN
+       access        (conj [:access access])))            ; ADMIN | USER      : ADMIN
+   nil
+   "*/*"])
 
 (defn delete-geofence-admin-rule [rule-id]
   ["DELETE"


### PR DESCRIPTION
## Purpose
This PR adds functions to `geosync.rest-api` to enable you to create, read, update, and delete GeoFence "Data Rules" and "Admin Rules", which provide fine-grained workspace and layer access control restrictions by user, role, and/or IP address range.

This PR does not yet provide an extension to GeoSync's `config.edn` file for auto-generating rules per workspace or layer filter. This should be submitted in a subsequent PR, so as to simplify the review process.

## Related Issues
I'm not sure which Jira ticket has been assigned to this effort.

## Submission Checklist
- [?] Included Jira issue in the PR title (e.g. `GEO1-### Did something here`)
- [X] Code passes linter rules (`clj-kondo --lint src`)
- [X] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
First, try running this script in your GeoSync REPL:

``` clojure
(require '[geosync.cli       :as cli]
         '[geosync.core      :as core]
         '[geosync.rest-api  :as rest]
         '[clojure.data.json :as json])

(def config-params
  (cli/add-derived-params {:geoserver-rest-uri "https://10.1.30.155:8443/geoserver/rest"
                           :geoserver-username "admin"
                           :geoserver-password "i%m%JNnW=O=1dv?X"}))

(defn submit-rest-request [rest-cmd]
  (some->> rest-cmd
           (core/make-rest-request config-params)
           (:body)
           (seq)
           (apply str)
           (json/read-str)))

(def rest-commands
  {:count-geofence-rules       (rest/count-geofence-rules)
   :get-geofence-rules         (rest/get-geofence-rules)
   :count-geofence-admin-rules (rest/count-geofence-admin-rules)
   :get-geofence-admin-rules   (rest/get-geofence-admin-rules)})

(update-vals rest-commands submit-rest-request)
```

Then feel free to experiment with `(submit-rest-request (rest/WHATEVER-FUNCTION-YOU_WANT ARGS))`.

You can view the private test GeoServer on mockingbird (once connected to the SIG VPN) here:

https://10.1.30.155:8443/geoserver/web/

Log in as the `admin` user with the credentials in the script above.

You can then navigate to the "GeoFence Data Rules" and "GeoFence Admin Rules" pages using their links at the bottom of the left-hand sidebar.

NOTE: Each time you run a GeoSync command that adds, updates, or deletes a rule, make sure to click the "GeoFence Data Rules" or "GeoFence Admin Rules" link in the sidebar again to reload the page. Simply refreshing the page in your web browser doesn't work unfortunately.