### PR TITLE
PYR1-1199 add clj-watson alias and command to the readme in a new section

### DIFF
--- a/README.org
+++ b/README.org
@@ -630,6 +630,8 @@ Once you have created the UberJAR, you can run it with the following command:
 java -jar $PATH_TO_JAR_DIR/geosync-$VERSION-standalone.jar $CLI_ARGS
 #+end_src
 
+** Vulerability checking
+To check for vulerabilities in this project, use ~clojure -M:clj-watson scan -p deps.edn -s~
 ** License and Distribution
 
 Copyright © 2020-2025 Spatial Informatics Group, LLC.

--- a/deps.edn
+++ b/deps.edn
@@ -25,4 +25,8 @@
                                             {:git/tag "v0.5.1"
                                              :git/sha "dfb30dd"}}
                               :main-opts   ["-m" "cognitect.test-runner"]
-                              :exec-fn     cognitect.test-runner.api/test}}}
+                              :exec-fn     cognitect.test-runner.api/test}
+           :clj-watson       {:replace-deps
+                              {io.github.clj-holmes/clj-watson
+                               {:git/tag "v6.0.1" :git/sha "b520351"}}
+                              :main-opts ["-m" "clj-watson.cli"]}}}


### PR DESCRIPTION
Purpose
Check for vulnerabilities

Related Issues
Closes PYR1-1199

Testing
See dev-docs for the environment variables that must be exported
Then call  clojure -M:clj-watson scan -p deps.edn -s
A report output must be sent to stdout (see jira ticket for samples)