### PR TITLE
Delete GeoWebCache tile layers when removing a workspace

### DIFF
--- a/src/geosync/core.clj
+++ b/src/geosync/core.clj
@@ -320,6 +320,24 @@
     (map :name %)
     (set %)))
 
+(defn get-existing-layers-in-workspace
+  "Bare layer names published under WORKSPACE.
+
+  Unlike get-existing-layers, the workspace is passed explicitly: remove-workspace!
+  iterates over every workspace matching the configured regex, not the single name
+  in config-params. GeoServer returns unqualified names here, so callers that need
+  a GeoWebCache layer name must join them as workspace:layer themselves. A
+  workspace with no layers yields an empty set rather than throwing."
+  [config-params workspace]
+  (as-> (rest/get-layers workspace) %
+    (make-rest-request config-params %)
+    (:body %)
+    (json/read-str % :key-fn keyword)
+    (:layers %)
+    (:layer %)
+    (map :name %)
+    (set %)))
+
 (defn get-existing-gwc-layer
   [{:keys [geoserver-workspace] :as config-params} store-name]
   (as-> (rest/get-cached-layer geoserver-workspace store-name) %
@@ -779,7 +797,19 @@
     (log (str (count workspaces) " workspaces are queued to be removed."))
     (reduce (fn [acc current-workspace]
               (call-sql "drop_existing_schema" current-workspace)
-              (let [delete-workspace-success?      (->> (rest/delete-workspace current-workspace true)
+              (let [cached-layers                  (get-existing-layers-in-workspace config-params
+                                                                                     current-workspace)
+                    ;; Must run BEFORE the workspace is deleted: once the catalog entry is
+                    ;; gone there is no way left to enumerate which layers it held, and the
+                    ;; tile layers become unreachable orphans. Deleting the workspace alone
+                    ;; leaves their blob directories and DiskQuota rows behind forever.
+                    ;; 404 counts as success -- the layer having no tile layer is the
+                    ;; outcome we want, not a failure.
+                    delete-cached-layers-success?  (->> cached-layers
+                                                        (mapv #(rest/delete-cached-layer current-workspace %))
+                                                        (make-parallel-rest-requests config-params)
+                                                        (every? #(or (success-code? %) (= 404 %))))
+                    delete-workspace-success?      (->> (rest/delete-workspace current-workspace true)
                                                         (make-rest-request config-params)
                                                         (:status)
                                                         (success-code?))
@@ -816,12 +846,14 @@
                                                         (every? success-code?))]
 
 
+                (when (seq cached-layers)
+                  (log (str (count cached-layers) " cached layers were removed from GeoWebCache.")))
                 (when (and layer-rules? delete-layer-rule-success?)
                   (log (str (count layer-rules-to-delete) " layer rules were removed.")))
                 (when (and geofence-rules? delete-geofence-data-success?)
                   (log (str (count geofence-data-rules-to-delete) " GeoFence data rules were deleted.")))
                 (when (and geofence-rules? delete-geofence-admin-success?)
                   (log (str (count geofence-admin-rules-to-delete) " GeoFence admin rules were deleted.")))
-                (and acc delete-workspace-success? delete-layer-rule-success?)))
+                (and acc delete-cached-layers-success? delete-workspace-success? delete-layer-rule-success?)))
             true
             workspaces)))

--- a/src/geosync/rest_api.clj
+++ b/src/geosync/rest_api.clj
@@ -848,6 +848,16 @@
         [:locale ""]]]]])
    "application/xml"])
 
+;; Removing a workspace from the GeoServer catalog does NOT reclaim the tile
+;; layer behind it: the blob directory under data/gwc and the layer's rows in the
+;; DiskQuota store both survive. This call reclaims both. Measured on staging:
+;; the blob directory disappears, and writing an equivalent number of fresh quota
+;; rows afterwards costs 83% less because the freed pages get reused.
+(defn delete-cached-layer [workspace layer]
+  ["DELETE"
+   (str "/../gwc/rest/layers/" workspace ":" layer)
+   nil])
+
 ;;===============================================================================================================
 ;;
 ;; Data Security (https://docs.geoserver.org/latest/en/api/#1.0.0/security.yaml)


### PR DESCRIPTION
`remove-workspace!` drops the Postgres schema, deletes the GeoServer workspace and cleans up layer and GeoFence rules — but never tells GeoWebCache anything.

The add path does the opposite. It reaches into GWC explicitly through `update-cached-layer` to set time param filters on every layer it registers. So geosync claims the tile layer on create and abandons it on destroy.

## What that leaves behind

Measured on production `geoserver-west`:

| | |
|---|---|
| Blob directories under `data/gwc` whose workspace is gone from the catalog | **423 of 522** |
| Oldest orphan | 2026-01-29 |
| DiskQuota H2 store | **107 GB** of sparse address space |

The DiskQuota store keeps a row set per layer name and never sees those names removed. On 2026-08-10 the kernel OOM-killed Tomcat on west; the page store was left dirty, and H2 recovery then pegged one core in `DiskFile.truncateStorage` for **33 minutes** without finishing. Tomcat only starts accepting on its connectors once every webapp has deployed, so all three GeoServers stayed down for the duration — port 443 bound but never accepting, `Recv-Q 101` against a backlog of 100.

The forecast pipeline mints roughly 9,400 new timestamped layer names per generation and turns over about four times a day. Every one of those names gets quota rows that outlive the layer.

## The change

- `rest_api.clj` — adds `delete-cached-layer`, the missing sibling of the existing `get-cached-layer` / `update-cached-layer`.
- `core.clj` — adds `get-existing-layers-in-workspace`, which takes the workspace explicitly because `remove-workspace!` iterates over every workspace matching the configured regex rather than the single name in `config-params`.
- `remove-workspace!` — deletes the workspace's tile layers through the existing `make-parallel-rest-requests` machinery.

Three details that are easy to get wrong:

1. **Ordering.** The enumeration is the *first* binding in the `let`, before `delete-workspace`. Once the catalog entry is gone there is no way left to discover which layers the workspace held, so deleting afterwards would create exactly the orphans this is meant to prevent.
2. **404 counts as success.** A layer with no tile layer is the state we are trying to reach, and `success-code?` does not include 404.
3. **Names are joined manually.** `/workspaces/<ws>/layers` returns *bare* names (`"active-fires"`), not qualified ones — verified against staging. The GWC URL builds `workspace:layer` itself; assuming qualified names would double-prefix and silently 404 on everything.

## Verification

Proven against `geoserver-stg` before any code was written:

- **Blob reclaim** — `DELETE /gwc/rest/layers/<ws>:<layer>` returns 200; the blob directory (45,464 B / 20 files) and the `gwc-layers` config both disappear. Repeated over 305 layers, every one a 200.
- **Quota rows are genuinely freed** — the store file never shrinks, since H2 reuses pages rather than truncating, so this was measured indirectly. Writing 300 fresh layers' worth of rows cost **8.18 MiB** with no preceding delete, and **1.43 MiB** after deleting 300 layers: an 83% reduction, i.e. the freed pages being reused. All 3,600 tile requests returned 200 in both phases.

Then, on this branch: `clj-kondo` clean (0 errors, 0 warnings), `clojure -M:check-reflection` loads with no new warnings, `clojure -M:test-runner` passes 4 tests / 18 assertions.

## Note for deployment

This stops the growth; it does not shrink what is already there. H2 never truncates, so production's existing stores (west's geoserver02 is at 99 GB sparse) still need a one-off move-aside on a planned restart.
