### PR TITLE
Add clj-kondo linter workflow

### DIFF
--- a/.github/workflows/clj-kondo.yml
+++ b/.github/workflows/clj-kondo.yml
@@ -1,0 +1,31 @@
+name: clj-kondo linter
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'src/**/*.clj'
+      - 'test/**/*.clj'
+      - 'deps.edn'
+      - '.github/workflows/clj-kondo.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clj-lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install clj-kondo
+      uses: DeLaGuardo/setup-clojure@13.6.0
+      with:
+        clj-kondo: latest
+
+    - name: Run clj-kondo
+      run: clj-kondo --lint src test --fail-level error


### PR DESCRIPTION
## Purpose
Adds a GitHub Actions workflow running clj-kondo on PRs to `main`, mirroring the setup in `pyrecast-gcp-deployment`.

1. Triggers on changes to `src/**/*.clj`, `test/**/*.clj`, `deps.edn`, or the workflow itself.
2. Installs clj-kondo via `DeLaGuardo/setup-clojure@13.6.0`.
3. Runs `clj-kondo --lint src test --fail-level error`.
4. Concurrency group cancels superseded runs on the same ref.

This enforces the existing PR checklist item "Code passes linter rules".

## Related Issues
None.

## Submission Checklist
- [ ] Included Jira issue in the PR title
- [x] Code passes linter rules (`clj-kondo --lint src`)
- [x] No new reflection warnings (no Clojure code changed)

## Testing
1. Given a clean clone of `main`, When running `clj-kondo --lint src test --fail-level error`, Then 9 files lint with 0 errors and 0 warnings and exit code 0.
2. Given a PR touching a `.clj` file under `src` or `test`, When the PR opens against `main`, Then the `clj-lint` job runs and fails only on error-level findings.
